### PR TITLE
feat: KIS API 인증, 시세 조회, 주문 모듈

### DIFF
--- a/backend/app/core/kis_config.py
+++ b/backend/app/core/kis_config.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+import yaml
+
+
+class KisEnvironment(StrEnum):
+    PAPER = "paper"  # 페이퍼 트레이딩 (더미)
+    VIRTUAL = "virtual"  # 모의투자
+    PRODUCTION = "production"  # 실전투자
+
+
+@dataclass
+class KisCredentials:
+    app_key: str
+    app_secret: str
+    account_no: str
+    hts_id: str = ""
+
+
+# KIS API 베이스 URL
+KIS_BASE_URLS = {
+    KisEnvironment.VIRTUAL: "https://openapivts.koreainvestment.com:29443",
+    KisEnvironment.PRODUCTION: "https://openapi.koreainvestment.com:9443",
+}
+
+
+def load_credentials(config_path: str | Path | None = None) -> KisCredentials:
+    """YAML 설정 파일에서 KIS 인증 정보를 로드."""
+    if config_path is None:
+        config_path = Path.home() / "KIS" / "config" / "kis_devlp.yaml"
+
+    config_path = Path(config_path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"KIS config not found: {config_path}")
+
+    with open(config_path, encoding="UTF-8") as f:
+        cfg = yaml.safe_load(f)
+
+    return KisCredentials(
+        app_key=cfg["my_app"],
+        app_secret=cfg["my_sec"],
+        account_no=cfg["my_acct"],
+        hts_id=cfg.get("my_id", ""),
+    )
+
+
+def get_base_url(env: KisEnvironment) -> str:
+    if env == KisEnvironment.PAPER:
+        raise ValueError("Paper environment does not use KIS API")
+    return KIS_BASE_URLS[env]

--- a/backend/app/services/kis_client.py
+++ b/backend/app/services/kis_client.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+
+import httpx
+
+from app.core.kis_config import KisCredentials, KisEnvironment, get_base_url
+
+
+class KisClient:
+    """한국투자증권 Open API 공통 클라이언트."""
+
+    def __init__(self, credentials: KisCredentials, env: KisEnvironment):
+        if env == KisEnvironment.PAPER:
+            raise ValueError("KisClient cannot be used in paper mode")
+
+        self.credentials = credentials
+        self.env = env
+        self.base_url = get_base_url(env)
+        self._token: str | None = None
+        self._token_expires_at: datetime | None = None
+        self._http = httpx.Client(base_url=self.base_url, timeout=10.0)
+
+    def _is_token_valid(self) -> bool:
+        if self._token is None or self._token_expires_at is None:
+            return False
+        return datetime.now() < self._token_expires_at
+
+    def get_token(self) -> str:
+        """접근토큰 발급. 유효한 토큰이 있으면 재사용."""
+        if self._is_token_valid():
+            return self._token
+
+        response = self._http.post(
+            "/oauth2/tokenP",
+            json={
+                "grant_type": "client_credentials",
+                "appkey": self.credentials.app_key,
+                "appsecret": self.credentials.app_secret,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        self._token = data["access_token"]
+        expires_in = int(data.get("expires_in", 86400))
+        self._token_expires_at = datetime.now() + timedelta(seconds=expires_in - 60)
+
+        return self._token
+
+    def _build_headers(self, tr_id: str) -> dict:
+        return {
+            "Content-Type": "application/json; charset=utf-8",
+            "authorization": f"Bearer {self.get_token()}",
+            "appkey": self.credentials.app_key,
+            "appsecret": self.credentials.app_secret,
+            "tr_id": tr_id,
+            "custtype": "P",
+        }
+
+    def get(self, path: str, tr_id: str, params: dict | None = None) -> dict:
+        headers = self._build_headers(tr_id)
+        response = self._http.get(path, headers=headers, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def post(self, path: str, tr_id: str, body: dict | None = None) -> dict:
+        headers = self._build_headers(tr_id)
+        response = self._http.post(path, headers=headers, json=body)
+        response.raise_for_status()
+        return response.json()
+
+    def close(self):
+        self._http.close()

--- a/backend/app/services/kis_market.py
+++ b/backend/app/services/kis_market.py
@@ -1,0 +1,58 @@
+from app.services.kis_client import KisClient
+from app.services.market_data import MarketDataProvider, PriceInfo
+
+# 모의투자 tr_id 매핑 (실전은 FHKST01010100 등)
+TR_ID_PRICE = {
+    "virtual": "FHKST01010100",
+    "production": "FHKST01010100",
+}
+
+
+class KisMarketDataProvider(MarketDataProvider):
+    """한국투자증권 API를 통한 실시간 시세 조회."""
+
+    def __init__(self, client: KisClient):
+        self.client = client
+
+    def get_price(self, code: str) -> PriceInfo:
+        """국내주식 현재가 조회."""
+        tr_id = TR_ID_PRICE[self.client.env]
+        data = self.client.get(
+            "/uapi/domestic-stock/v1/quotations/inquire-price",
+            tr_id=tr_id,
+            params={"FID_COND_MRKT_DIV_CODE": "J", "FID_INPUT_ISCD": code},
+        )
+
+        output = data["output"]
+        return PriceInfo(
+            code=code,
+            current_price=float(output["stck_prpr"]),
+            high=float(output["stck_hgpr"]),
+            low=float(output["stck_lwpr"]),
+            volume=int(output["acml_vol"]),
+        )
+
+    def get_daily_prices(self, code: str, period: str = "D") -> list[dict]:
+        """국내주식 일봉/주봉/월봉 조회."""
+        tr_id = "FHKST01010400"
+        data = self.client.get(
+            "/uapi/domestic-stock/v1/quotations/inquire-daily-price",
+            tr_id=tr_id,
+            params={
+                "FID_COND_MRKT_DIV_CODE": "J",
+                "FID_INPUT_ISCD": code,
+                "FID_PERIOD_DIV_CODE": period,
+                "FID_ORG_ADJ_PRC": "0",
+            },
+        )
+        return data.get("output", [])
+
+    def get_orderbook(self, code: str) -> dict:
+        """국내주식 호가 조회."""
+        tr_id = "FHKST01010200"
+        data = self.client.get(
+            "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+            tr_id=tr_id,
+            params={"FID_COND_MRKT_DIV_CODE": "J", "FID_INPUT_ISCD": code},
+        )
+        return data.get("output1", {})

--- a/backend/app/services/kis_order.py
+++ b/backend/app/services/kis_order.py
@@ -1,0 +1,78 @@
+from app.services.kis_client import KisClient
+
+# 모의투자 tr_id
+TR_ID_ORDER = {
+    "virtual": {"buy": "VTTC0802U", "sell": "VTTC0801U"},
+    "production": {"buy": "TTTC0802U", "sell": "TTTC0801U"},
+}
+
+TR_ID_BALANCE = {
+    "virtual": "VTTC8434R",
+    "production": "TTTC8434R",
+}
+
+
+class KisOrderService:
+    """한국투자증권 API를 통한 주문 실행."""
+
+    def __init__(self, client: KisClient):
+        self.client = client
+
+    def buy(self, code: str, quantity: int, price: int = 0, order_type: str = "00") -> dict:
+        """매수 주문.
+        order_type: "00" 지정가, "01" 시장가
+        price: 시장가일 경우 0
+        """
+        tr_id = TR_ID_ORDER[self.client.env]["buy"]
+        account = self.client.credentials.account_no
+        return self.client.post(
+            "/uapi/domestic-stock/v1/trading/order-cash",
+            tr_id=tr_id,
+            body={
+                "CANO": account[:8],
+                "ACNT_PRDT_CD": account[8:],
+                "PDNO": code,
+                "ORD_DVSN": order_type,
+                "ORD_QTY": str(quantity),
+                "ORD_UNPR": str(price),
+            },
+        )
+
+    def sell(self, code: str, quantity: int, price: int = 0, order_type: str = "00") -> dict:
+        """매도 주문."""
+        tr_id = TR_ID_ORDER[self.client.env]["sell"]
+        account = self.client.credentials.account_no
+        return self.client.post(
+            "/uapi/domestic-stock/v1/trading/order-cash",
+            tr_id=tr_id,
+            body={
+                "CANO": account[:8],
+                "ACNT_PRDT_CD": account[8:],
+                "PDNO": code,
+                "ORD_DVSN": order_type,
+                "ORD_QTY": str(quantity),
+                "ORD_UNPR": str(price),
+            },
+        )
+
+    def get_balance(self) -> dict:
+        """잔고 조회."""
+        tr_id = TR_ID_BALANCE[self.client.env]
+        account = self.client.credentials.account_no
+        return self.client.get(
+            "/uapi/domestic-stock/v1/trading/inquire-balance",
+            tr_id=tr_id,
+            params={
+                "CANO": account[:8],
+                "ACNT_PRDT_CD": account[8:],
+                "AFHR_FLPR_YN": "N",
+                "OFL_YN": "",
+                "INQR_DVSN": "02",
+                "UNPR_DVSN": "01",
+                "FUND_STTL_ICLD_YN": "N",
+                "FNCG_AMT_AUTO_RDPT_YN": "N",
+                "PRCS_DVSN": "01",
+                "CTX_AREA_FK100": "",
+                "CTX_AREA_NK100": "",
+            },
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "alembic>=1.13.0",
     "fastapi[standard]>=0.115.0",
+    "httpx>=0.28.1",
     "pydantic-settings>=2.0.0",
     "sqlalchemy>=2.0.0",
 ]
@@ -28,5 +29,6 @@ testpaths = ["tests"]
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "respx>=0.23.1",
     "ruff>=0.15.12",
 ]

--- a/backend/tests/test_kis_client.py
+++ b/backend/tests/test_kis_client.py
@@ -1,0 +1,189 @@
+import pytest
+import respx
+from httpx import Response
+
+from app.core.kis_config import KisCredentials, KisEnvironment, get_base_url, load_credentials
+from app.services.kis_client import KisClient
+from app.services.kis_market import KisMarketDataProvider
+from app.services.kis_order import KisOrderService
+
+MOCK_CREDENTIALS = KisCredentials(
+    app_key="test_app_key",
+    app_secret="test_app_secret",
+    account_no="1234567801",
+    hts_id="testuser",
+)
+
+BASE_URL = get_base_url(KisEnvironment.VIRTUAL)
+
+
+def _mock_token(router: respx.MockRouter):
+    router.post("/oauth2/tokenP").mock(
+        return_value=Response(
+            200,
+            json={"access_token": "mock_token_123", "token_type": "Bearer", "expires_in": 86400},
+        )
+    )
+
+
+# --- Config tests ---
+
+
+def test_get_base_url_virtual():
+    assert "openapivts" in get_base_url(KisEnvironment.VIRTUAL)
+
+
+def test_get_base_url_production():
+    assert "openapi.koreainvestment" in get_base_url(KisEnvironment.PRODUCTION)
+
+
+def test_get_base_url_paper_raises():
+    with pytest.raises(ValueError):
+        get_base_url(KisEnvironment.PAPER)
+
+
+def test_load_credentials_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_credentials("/nonexistent/path.yaml")
+
+
+# --- Client tests ---
+
+
+def test_get_token():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        token = client.get_token()
+        assert token == "mock_token_123"
+        client.close()
+
+
+def test_token_reuse():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        client.get_token()
+        client.get_token()
+        assert mock.calls.call_count == 1
+        client.close()
+
+
+def test_get_request():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.get("/uapi/test").mock(return_value=Response(200, json={"result": "ok"}))
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        result = client.get("/uapi/test", tr_id="TEST001")
+        assert result["result"] == "ok"
+        client.close()
+
+
+def test_post_request():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.post("/uapi/test").mock(return_value=Response(200, json={"status": "created"}))
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        result = client.post("/uapi/test", tr_id="TEST002", body={"data": "value"})
+        assert result["status"] == "created"
+        client.close()
+
+
+def test_paper_mode_raises():
+    with pytest.raises(ValueError):
+        KisClient(MOCK_CREDENTIALS, KisEnvironment.PAPER)
+
+
+# --- Market data tests ---
+
+
+def test_kis_get_price():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.get("/uapi/domestic-stock/v1/quotations/inquire-price").mock(
+            return_value=Response(
+                200,
+                json={
+                    "output": {
+                        "stck_prpr": "70000",
+                        "stck_hgpr": "71000",
+                        "stck_lwpr": "69000",
+                        "acml_vol": "5000000",
+                    }
+                },
+            )
+        )
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        provider = KisMarketDataProvider(client)
+        price = provider.get_price("005930")
+
+        assert price.code == "005930"
+        assert price.current_price == 70000
+        assert price.high == 71000
+        assert price.volume == 5000000
+        client.close()
+
+
+def test_kis_get_daily_prices():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.get("/uapi/domestic-stock/v1/quotations/inquire-daily-price").mock(
+            return_value=Response(200, json={"output": [{"stck_bsop_date": "20260101", "stck_clpr": "70000"}]})
+        )
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        provider = KisMarketDataProvider(client)
+        prices = provider.get_daily_prices("005930")
+
+        assert len(prices) == 1
+        client.close()
+
+
+# --- Order tests ---
+
+
+def test_kis_buy_order():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.post("/uapi/domestic-stock/v1/trading/order-cash").mock(
+            return_value=Response(
+                200,
+                json={"rt_cd": "0", "msg1": "정상처리", "output": {"ODNO": "0001234567"}},
+            )
+        )
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        service = KisOrderService(client)
+        result = service.buy("005930", quantity=10, price=70000)
+        assert result["rt_cd"] == "0"
+        client.close()
+
+
+def test_kis_sell_order():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.post("/uapi/domestic-stock/v1/trading/order-cash").mock(
+            return_value=Response(200, json={"rt_cd": "0", "msg1": "정상처리", "output": {"ODNO": "0001234568"}})
+        )
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        service = KisOrderService(client)
+        result = service.sell("005930", quantity=5, price=72000)
+        assert result["rt_cd"] == "0"
+        client.close()
+
+
+def test_kis_get_balance():
+    with respx.mock(base_url=BASE_URL) as mock:
+        _mock_token(mock)
+        mock.get("/uapi/domestic-stock/v1/trading/inquire-balance").mock(
+            return_value=Response(
+                200,
+                json={
+                    "output1": [{"pdno": "005930", "hldg_qty": "10"}],
+                    "output2": [{"tot_evlu_amt": "700000"}],
+                },
+            )
+        )
+        client = KisClient(MOCK_CREDENTIALS, KisEnvironment.VIRTUAL)
+        service = KisOrderService(client)
+        result = service.get_balance()
+        assert result["output1"][0]["pdno"] == "005930"
+        client.close()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -440,6 +440,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "sqlalchemy" },
 ]
@@ -447,6 +448,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -455,6 +457,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
@@ -462,6 +465,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.12" },
 ]
 
@@ -835,6 +839,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
한국투자증권 Open API 연동 모듈 구현. 인증, 시세, 주문 3개 Issue 통합.

Closes #4
Closes #5
Closes #6

## Changes
- **인증 모듈** (`kis_config.py`, `kis_client.py`)
  - YAML 설정 파일 로딩
  - 환경 전환 (paper/virtual/production)
  - 토큰 발급/갱신/캐싱 (24시간 유효)
  - GET/POST 공통 클라이언트

- **시세 조회** (`kis_market.py`)
  - 현재가 조회 (MarketDataProvider 인터페이스 구현)
  - 일봉/주봉/월봉 조회
  - 호가 조회

- **주문** (`kis_order.py`)
  - 매수/매도 (지정가/시장가)
  - 잔고 조회

- **테스트** — respx로 API 호출 전체 모킹 (14건 추가, 총 31 passed)

## Checklist
- [x] Conventional Commits 메시지 작성
- [x] ruff lint/format 통과
- [x] 테스트 추가 또는 기존 테스트 통과 (31 passed)
- [x] CLAUDE.md 또는 README.md 업데이트 필요 여부 확인