### PR TITLE
chore: CI에 프론트엔드 lint/build 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,28 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -v
+
+  frontend:
+    name: Frontend Lint & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
CI 파이프라인에 프론트엔드 ESLint + Next.js 빌드 검증 추가

## Changes
- Frontend job: npm ci → lint → build
- Node.js 20 + npm cache 설정

## Checklist
- [x] Conventional Commits 메시지 작성
- [x] CI 설정 확인