### PR TITLE
feat: 주문 생성 폼 + 자동매매 관리 UI

### DIFF
--- a/frontend/src/app/auto-trade/page.tsx
+++ b/frontend/src/app/auto-trade/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchApi,
+  type AutoTradeConfig,
+  type AutoTradeLog,
+  type SchedulerStatus,
+  type StrategyInfo,
+} from "@/lib/api";
+
+const PRESET_STOCKS = [
+  { code: "005930", name: "삼성전자" },
+  { code: "000660", name: "SK하이닉스" },
+  { code: "035420", name: "NAVER" },
+  { code: "051910", name: "LG화학" },
+  { code: "006400", name: "삼성SDI" },
+];
+
+export default function AutoTradePage() {
+  const [configs, setConfigs] = useState<AutoTradeConfig[]>([]);
+  const [logs, setLogs] = useState<AutoTradeLog[]>([]);
+  const [strategies, setStrategies] = useState<StrategyInfo[]>([]);
+  const [scheduler, setScheduler] = useState<SchedulerStatus>({ running: false });
+  const [error, setError] = useState("");
+
+  // 새 설정 폼
+  const [newCode, setNewCode] = useState("");
+  const [newName, setNewName] = useState("");
+  const [newStrategy, setNewStrategy] = useState("");
+  const [newQty, setNewQty] = useState("10");
+
+  function loadAll() {
+    fetchApi<AutoTradeConfig[]>("/api/auto-trade/configs").then(setConfigs).catch(() => {});
+    fetchApi<AutoTradeLog[]>("/api/auto-trade/logs?limit=20").then(setLogs).catch(() => {});
+    fetchApi<SchedulerStatus>("/api/auto-trade/scheduler/status").then(setScheduler).catch(() => {});
+  }
+
+  useEffect(() => {
+    fetchApi<StrategyInfo[]>("/api/strategy/list").then((s) => {
+      setStrategies(s);
+      if (s.length > 0) setNewStrategy(s[0].name);
+    }).catch(() => {});
+    loadAll();
+  }, []);
+
+  async function handleAddConfig() {
+    if (!newCode || !newStrategy) return;
+    try {
+      await fetchApi("/api/auto-trade/configs", {
+        method: "POST",
+        body: JSON.stringify({
+          stock_code: newCode,
+          stock_name: newName,
+          strategy_name: newStrategy,
+          quantity: parseInt(newQty),
+        }),
+      });
+      setNewCode("");
+      setNewName("");
+      loadAll();
+    } catch {
+      setError("설정 추가 실패");
+    }
+  }
+
+  async function handleToggle(id: number) {
+    await fetchApi(`/api/auto-trade/configs/${id}/toggle`, { method: "PATCH" });
+    loadAll();
+  }
+
+  async function handleDelete(id: number) {
+    await fetchApi(`/api/auto-trade/configs/${id}`, { method: "DELETE" });
+    loadAll();
+  }
+
+  async function handleScheduler(action: "start" | "stop") {
+    await fetchApi(`/api/auto-trade/scheduler/${action}`, { method: "POST" });
+    loadAll();
+  }
+
+  async function handleTrigger() {
+    await fetchApi("/api/auto-trade/scheduler/trigger", { method: "POST" });
+    loadAll();
+  }
+
+  function selectPreset(stock: { code: string; name: string }) {
+    setNewCode(stock.code);
+    setNewName(stock.name);
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">자동매매</h1>
+        <div className="flex items-center gap-3">
+          <span
+            className={`inline-block h-3 w-3 rounded-full ${scheduler.running ? "bg-green-400" : "bg-gray-600"}`}
+          />
+          <span className="text-sm text-gray-400">
+            {scheduler.running ? "스케줄러 실행 중" : "스케줄러 중지"}
+          </span>
+          {scheduler.running ? (
+            <button
+              onClick={() => handleScheduler("stop")}
+              className="rounded bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700"
+            >
+              중지
+            </button>
+          ) : (
+            <button
+              onClick={() => handleScheduler("start")}
+              className="rounded bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700"
+            >
+              시작
+            </button>
+          )}
+          <button
+            onClick={handleTrigger}
+            className="rounded border border-gray-600 px-3 py-1.5 text-sm text-gray-300 hover:border-white hover:text-white"
+          >
+            수동 실행
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="text-red-400">{error}</p>}
+
+      {/* 새 설정 추가 */}
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-6">
+        <h2 className="text-lg font-semibold mb-4">전략 설정 추가</h2>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {PRESET_STOCKS.map((s) => (
+            <button
+              key={s.code}
+              onClick={() => selectPreset(s)}
+              className={`rounded border px-3 py-1.5 text-sm transition-colors ${
+                newCode === s.code
+                  ? "border-blue-500 text-white"
+                  : "border-gray-700 text-gray-400 hover:border-blue-500"
+              }`}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-3 items-end">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">종목 코드</label>
+            <input
+              value={newCode}
+              onChange={(e) => setNewCode(e.target.value)}
+              placeholder="005930"
+              className="w-28 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">종목명</label>
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="삼성전자"
+              className="w-28 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">전략</label>
+            <select
+              value={newStrategy}
+              onChange={(e) => setNewStrategy(e.target.value)}
+              className="rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+            >
+              {strategies.map((s) => (
+                <option key={s.name} value={s.name}>
+                  {s.name} — {s.description}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">수량</label>
+            <input
+              type="number"
+              min="1"
+              value={newQty}
+              onChange={(e) => setNewQty(e.target.value)}
+              className="w-20 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+            />
+          </div>
+          <button
+            onClick={handleAddConfig}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            추가
+          </button>
+        </div>
+      </div>
+
+      {/* 설정 목록 */}
+      {configs.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-gray-800">
+          <table className="w-full text-left">
+            <thead className="bg-gray-900 text-sm text-gray-400">
+              <tr>
+                <th className="px-4 py-3">종목</th>
+                <th className="px-4 py-3">전략</th>
+                <th className="px-4 py-3 text-right">수량</th>
+                <th className="px-4 py-3">상태</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {configs.map((c) => (
+                <tr key={c.id} className="hover:bg-gray-900/50">
+                  <td className="px-4 py-3">
+                    <span className="font-medium">{c.stock_code}</span>
+                    {c.stock_name && (
+                      <span className="ml-2 text-sm text-gray-500">{c.stock_name}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-gray-300">{c.strategy_name}</td>
+                  <td className="px-4 py-3 text-right">{c.quantity}</td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => handleToggle(c.id)}
+                      className={`rounded px-2 py-1 text-xs font-medium ${
+                        c.is_active
+                          ? "bg-green-900 text-green-300"
+                          : "bg-gray-800 text-gray-500"
+                      }`}
+                    >
+                      {c.is_active ? "활성" : "비활성"}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => handleDelete(c.id)}
+                      className="text-sm text-red-400 hover:text-red-300"
+                    >
+                      삭제
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* 실행 로그 */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">실행 로그</h2>
+        {logs.length === 0 ? (
+          <p className="text-gray-500">실행 로그가 없습니다.</p>
+        ) : (
+          <div className="space-y-2 max-h-96 overflow-y-auto">
+            {logs.map((log) => (
+              <div
+                key={log.id}
+                className="flex items-center gap-3 rounded border border-gray-800 bg-gray-900 px-4 py-2 text-sm"
+              >
+                <span className="text-gray-500 text-xs w-36 shrink-0">
+                  {log.created_at}
+                </span>
+                <span className="font-medium w-16">{log.stock_code}</span>
+                <span className="text-gray-400 w-24">{log.strategy_name}</span>
+                <span
+                  className={`w-12 font-medium ${
+                    log.signal === "buy"
+                      ? "text-red-400"
+                      : log.signal === "sell"
+                        ? "text-blue-400"
+                        : "text-gray-500"
+                  }`}
+                >
+                  {log.signal.toUpperCase()}
+                </span>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded ${
+                    log.action_taken === "order_placed"
+                      ? "bg-green-900 text-green-300"
+                      : log.action_taken === "error"
+                        ? "bg-red-900 text-red-300"
+                        : "bg-gray-800 text-gray-500"
+                  }`}
+                >
+                  {log.action_taken}
+                </span>
+                <span className="text-gray-500 text-xs truncate flex-1">
+                  {log.reason}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -21,6 +21,7 @@ export const metadata: Metadata = {
 const navItems = [
   { href: "/", label: "대시보드" },
   { href: "/market", label: "시세 조회" },
+  { href: "/auto-trade", label: "자동매매" },
   { href: "/portfolio", label: "포트폴리오" },
   { href: "/orders", label: "주문 내역" },
 ];

--- a/frontend/src/app/market/page.tsx
+++ b/frontend/src/app/market/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { fetchApi, type PriceInfo } from "@/lib/api";
+import { fetchApi, type Order, type PriceInfo } from "@/lib/api";
 
 const PRESET_STOCKS = [
   { code: "005930", name: "삼성전자" },
@@ -16,6 +16,11 @@ export default function MarketPage() {
   const [price, setPrice] = useState<PriceInfo | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [orderSide, setOrderSide] = useState<"buy" | "sell">("buy");
+  const [orderType, setOrderType] = useState<"market" | "limit">("market");
+  const [orderQty, setOrderQty] = useState("1");
+  const [orderPrice, setOrderPrice] = useState("");
+  const [orderMsg, setOrderMsg] = useState("");
 
   async function handleSearch(stockCode: string) {
     setLoading(true);
@@ -99,6 +104,88 @@ export default function MarketPage() {
               </p>
             </div>
           </div>
+        </div>
+      )}
+      {/* 주문 생성 */}
+      {price && (
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-6">
+          <h2 className="text-lg font-semibold mb-4">주문</h2>
+          <div className="flex flex-wrap gap-3 items-end">
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">매매</label>
+              <select
+                value={orderSide}
+                onChange={(e) => setOrderSide(e.target.value as "buy" | "sell")}
+                className="rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+              >
+                <option value="buy">매수</option>
+                <option value="sell">매도</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">유형</label>
+              <select
+                value={orderType}
+                onChange={(e) => setOrderType(e.target.value as "market" | "limit")}
+                className="rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+              >
+                <option value="market">시장가</option>
+                <option value="limit">지정가</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">수량</label>
+              <input
+                type="number"
+                min="1"
+                value={orderQty}
+                onChange={(e) => setOrderQty(e.target.value)}
+                className="w-24 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+              />
+            </div>
+            {orderType === "limit" && (
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">가격</label>
+                <input
+                  type="number"
+                  value={orderPrice}
+                  onChange={(e) => setOrderPrice(e.target.value)}
+                  placeholder={price.current_price.toString()}
+                  className="w-32 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white"
+                />
+              </div>
+            )}
+            <button
+              onClick={async () => {
+                try {
+                  setOrderMsg("");
+                  await fetchApi<Order>("/api/orders", {
+                    method: "POST",
+                    body: JSON.stringify({
+                      stock_code: price.code,
+                      side: orderSide,
+                      order_type: orderType,
+                      quantity: parseInt(orderQty),
+                      price: orderType === "limit" ? parseFloat(orderPrice) : null,
+                    }),
+                  });
+                  setOrderMsg(`${orderSide === "buy" ? "매수" : "매도"} 주문 생성 완료`);
+                } catch {
+                  setOrderMsg("주문 생성 실패");
+                }
+              }}
+              className={`rounded px-4 py-2 font-medium text-white ${
+                orderSide === "buy"
+                  ? "bg-red-600 hover:bg-red-700"
+                  : "bg-blue-600 hover:bg-blue-700"
+              }`}
+            >
+              {orderSide === "buy" ? "매수" : "매도"}
+            </button>
+          </div>
+          {orderMsg && (
+            <p className="mt-3 text-sm text-green-400">{orderMsg}</p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,3 +37,34 @@ export interface PortfolioItem {
   quantity: number;
   avg_price: number;
 }
+
+export interface AutoTradeConfig {
+  id: number;
+  stock_code: string;
+  stock_name: string;
+  strategy_name: string;
+  is_active: boolean;
+  quantity: number;
+  max_invest_amount: number;
+}
+
+export interface AutoTradeLog {
+  id: number;
+  config_id: number;
+  stock_code: string;
+  strategy_name: string;
+  signal: string;
+  reason: string;
+  action_taken: string;
+  order_id: number | null;
+  created_at: string;
+}
+
+export interface SchedulerStatus {
+  running: boolean;
+}
+
+export interface StrategyInfo {
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
## Summary
프론트엔드에서 주문 생성, 자동매매 전략 설정/관리, 스케줄러 제어, 실행 로그 확인 가능

Closes #30

## Changes
- **시세 조회 페이지**: 주문 생성 폼 추가 (매수/매도, 시장가/지정가, 수량, 가격)
- **자동매매 페이지** (`/auto-trade`): 
  - 전략 설정 추가 (종목 프리셋 + 전략 선택 + 수량)
  - 설정 목록 (활성/비활성 토글, 삭제)
  - 스케줄러 시작/중지/수동 실행
  - 실행 로그 실시간 표시
- **네비게이션**: 자동매매 메뉴 추가
- **API 타입**: AutoTradeConfig, AutoTradeLog, SchedulerStatus, StrategyInfo

## Checklist
- [x] Conventional Commits 메시지 작성
- [x] ESLint 통과
- [x] Next.js 빌드 통과