### PR TITLE
feat: 안전장치 - kill switch, 일일 한도, 손절/익절

### DIFF
--- a/backend/app/api/safety.py
+++ b/backend/app/api/safety.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.services.safety import get_daily_stats, safety
+
+router = APIRouter(prefix="/api/safety", tags=["safety"])
+
+
+class SafetyStatus(BaseModel):
+    date: str
+    trade_count: int
+    trade_amount: float
+    max_trades: int
+    max_amount: float
+    kill_switch: bool
+    stop_loss_pct: float
+    take_profit_pct: float
+
+
+@router.get("/status", response_model=SafetyStatus)
+def status(db: Session = Depends(get_db)):
+    return get_daily_stats(db)
+
+
+class KillSwitchRequest(BaseModel):
+    active: bool
+
+
+@router.post("/kill-switch", response_model=SafetyStatus)
+def set_kill_switch(req: KillSwitchRequest, db: Session = Depends(get_db)):
+    safety.kill_switch = req.active
+    return get_daily_stats(db)
+
+
+class SafetyConfigUpdate(BaseModel):
+    daily_max_trades: int | None = None
+    daily_max_amount: float | None = None
+    stop_loss_pct: float | None = None
+    take_profit_pct: float | None = None
+
+
+@router.patch("/config", response_model=SafetyStatus)
+def update_config(req: SafetyConfigUpdate, db: Session = Depends(get_db)):
+    if req.daily_max_trades is not None:
+        safety.daily_max_trades = req.daily_max_trades
+    if req.daily_max_amount is not None:
+        safety.daily_max_amount = req.daily_max_amount
+    if req.stop_loss_pct is not None:
+        safety.stop_loss_pct = req.stop_loss_pct
+    if req.take_profit_pct is not None:
+        safety.take_profit_pct = req.take_profit_pct
+    return get_daily_stats(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auto_trade import router as auto_trade_router
 from app.api.health import router as health_router
+from app.api.safety import router as safety_router
 from app.api.strategy import router as strategy_router
 from app.api.trading import router as trading_router
 from app.core.config import settings
@@ -34,3 +35,4 @@ app.include_router(health_router)
 app.include_router(trading_router)
 app.include_router(strategy_router)
 app.include_router(auto_trade_router)
+app.include_router(safety_router)

--- a/backend/app/services/auto_trader.py
+++ b/backend/app/services/auto_trader.py
@@ -4,8 +4,10 @@ from sqlalchemy.orm import Session
 
 from app.models.auto_trade import AutoTradeConfig, AutoTradeLog
 from app.models.order import OrderSide, OrderType
+from app.models.portfolio import PortfolioItem
 from app.services.market_data import MarketDataProvider
 from app.services.order_service import submit_order
+from app.services.safety import check_can_trade, check_stop_loss_take_profit, safety
 from app.strategies.base import Signal
 from app.strategies.runner import get_strategy, run_strategy
 
@@ -14,9 +16,17 @@ logger = logging.getLogger(__name__)
 
 def run_auto_trade_cycle(db: Session, market: MarketDataProvider) -> list[AutoTradeLog]:
     """활성화된 모든 자동매매 설정에 대해 전략 실행 → 시그널 발생 시 주문."""
+    if safety.kill_switch:
+        logger.warning("Kill switch active — skipping all auto trades")
+        return []
+
     configs = db.query(AutoTradeConfig).filter_by(is_active=True).all()
     logs = []
 
+    # 1. 손절/익절 체크
+    _check_portfolio_safety(db, market)
+
+    # 2. 전략 실행
     for config in configs:
         log = _process_config(db, market, config)
         logs.append(log)
@@ -25,18 +35,46 @@ def run_auto_trade_cycle(db: Session, market: MarketDataProvider) -> list[AutoTr
     return logs
 
 
+def _check_portfolio_safety(db: Session, market: MarketDataProvider):
+    """보유 종목 손절/익절 자동 매도."""
+    items = db.query(PortfolioItem).all()
+    for item in items:
+        if item.quantity <= 0:
+            continue
+        price_info = market.get_price(item.stock_code)
+        trigger = check_stop_loss_take_profit(
+            db, item.stock_code, price_info.current_price, float(item.avg_price), item.quantity
+        )
+        if trigger:
+            can_trade, reason = check_can_trade(price_info.current_price, item.quantity)
+            if can_trade:
+                order = submit_order(
+                    db,
+                    stock_code=item.stock_code,
+                    side=OrderSide.SELL,
+                    order_type=OrderType.MARKET,
+                    quantity=item.quantity,
+                )
+                safety.record_trade(price_info.current_price * item.quantity)
+                logger.warning(
+                    "%s %s x%d @ %s (order #%d)",
+                    trigger.upper(),
+                    item.stock_code,
+                    item.quantity,
+                    price_info.current_price,
+                    order.id,
+                )
+
+
 def _process_config(db: Session, market: MarketDataProvider, config: AutoTradeConfig) -> AutoTradeLog:
     try:
-        # 시세 데이터 수집 (최근 30개)
         prices = [market.get_price(config.stock_code).current_price for _ in range(30)]
 
-        # 전략 실행
         strategy = get_strategy(config.strategy_name)
         result = run_strategy(strategy, config.stock_code, prices)
         signal = result.result.signal
         reason = result.result.reason
 
-        # 시그널에 따라 주문
         action = "skipped"
         order_id = None
 
@@ -44,28 +82,39 @@ def _process_config(db: Session, market: MarketDataProvider, config: AutoTradeCo
             current_price = prices[0]
             affordable_qty = min(config.quantity, int(config.max_invest_amount / current_price))
             if affordable_qty > 0:
+                can_trade, block_reason = check_can_trade(current_price, affordable_qty)
+                if can_trade:
+                    order = submit_order(
+                        db,
+                        stock_code=config.stock_code,
+                        side=OrderSide.BUY,
+                        order_type=OrderType.MARKET,
+                        quantity=affordable_qty,
+                    )
+                    safety.record_trade(current_price * affordable_qty)
+                    action = "order_placed"
+                    order_id = order.id
+                else:
+                    action = "blocked"
+                    reason = block_reason
+
+        elif signal == Signal.SELL:
+            current_price = prices[0]
+            can_trade, block_reason = check_can_trade(current_price, config.quantity)
+            if can_trade:
                 order = submit_order(
                     db,
                     stock_code=config.stock_code,
-                    side=OrderSide.BUY,
+                    side=OrderSide.SELL,
                     order_type=OrderType.MARKET,
-                    quantity=affordable_qty,
+                    quantity=config.quantity,
                 )
+                safety.record_trade(current_price * config.quantity)
                 action = "order_placed"
                 order_id = order.id
-                logger.info("BUY %s x%d (전략: %s)", config.stock_code, affordable_qty, config.strategy_name)
-
-        elif signal == Signal.SELL:
-            order = submit_order(
-                db,
-                stock_code=config.stock_code,
-                side=OrderSide.SELL,
-                order_type=OrderType.MARKET,
-                quantity=config.quantity,
-            )
-            action = "order_placed"
-            order_id = order.id
-            logger.info("SELL %s x%d (전략: %s)", config.stock_code, config.quantity, config.strategy_name)
+            else:
+                action = "blocked"
+                reason = block_reason
 
     except Exception as e:
         signal = Signal.HOLD

--- a/backend/app/services/safety.py
+++ b/backend/app/services/safety.py
@@ -1,0 +1,107 @@
+"""안전장치 모듈: 일일 한도, 손절/익절, kill switch."""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SafetyConfig:
+    """안전장치 설정. 런타임에서 관리."""
+
+    # Kill switch
+    kill_switch: bool = False
+
+    # 일일 한도
+    daily_max_trades: int = 50
+    daily_max_amount: float = 10_000_000  # 일일 최대 매매 금액
+
+    # 손절/익절 (%)
+    stop_loss_pct: float = -5.0  # -5% 손실 시 자동 매도
+    take_profit_pct: float = 10.0  # +10% 이익 시 자동 매도
+
+    # 일일 카운터 (자동 리셋)
+    _today: date = field(default_factory=date.today)
+    _daily_trade_count: int = 0
+    _daily_trade_amount: float = 0.0
+
+    def _reset_if_new_day(self):
+        today = date.today()
+        if today != self._today:
+            self._today = today
+            self._daily_trade_count = 0
+            self._daily_trade_amount = 0.0
+
+    def record_trade(self, amount: float):
+        self._reset_if_new_day()
+        self._daily_trade_count += 1
+        self._daily_trade_amount += amount
+
+    @property
+    def daily_trade_count(self) -> int:
+        self._reset_if_new_day()
+        return self._daily_trade_count
+
+    @property
+    def daily_trade_amount(self) -> float:
+        self._reset_if_new_day()
+        return self._daily_trade_amount
+
+
+# 글로벌 안전장치 인스턴스
+safety = SafetyConfig()
+
+
+def check_can_trade(price: float, quantity: int) -> tuple[bool, str]:
+    """주문 가능 여부 확인. (가능 여부, 사유) 반환."""
+    if safety.kill_switch:
+        return False, "Kill switch 활성화 — 모든 매매 중지"
+
+    safety._reset_if_new_day()
+
+    if safety.daily_trade_count >= safety.daily_max_trades:
+        return False, f"일일 매매 횟수 한도 초과 ({safety.daily_max_trades}회)"
+
+    trade_amount = price * quantity
+    if safety.daily_trade_amount + trade_amount > safety.daily_max_amount:
+        return False, f"일일 매매 금액 한도 초과 ({safety.daily_max_amount:,.0f}원)"
+
+    return True, "OK"
+
+
+def check_stop_loss_take_profit(
+    db: Session, stock_code: str, current_price: float, avg_price: float, quantity: int
+) -> str | None:
+    """손절/익절 조건 확인. 매도 필요 시 'stop_loss' 또는 'take_profit' 반환."""
+    if avg_price <= 0 or quantity <= 0:
+        return None
+
+    pnl_pct = (current_price - avg_price) / avg_price * 100
+
+    if pnl_pct <= safety.stop_loss_pct:
+        logger.warning("STOP LOSS triggered: %s (%.1f%%)", stock_code, pnl_pct)
+        return "stop_loss"
+
+    if pnl_pct >= safety.take_profit_pct:
+        logger.info("TAKE PROFIT triggered: %s (%.1f%%)", stock_code, pnl_pct)
+        return "take_profit"
+
+    return None
+
+
+def get_daily_stats(db: Session) -> dict:
+    """오늘의 매매 통계."""
+    return {
+        "date": str(safety._today),
+        "trade_count": safety.daily_trade_count,
+        "trade_amount": safety.daily_trade_amount,
+        "max_trades": safety.daily_max_trades,
+        "max_amount": safety.daily_max_amount,
+        "kill_switch": safety.kill_switch,
+        "stop_loss_pct": safety.stop_loss_pct,
+        "take_profit_pct": safety.take_profit_pct,
+    }

--- a/backend/tests/test_safety.py
+++ b/backend/tests/test_safety.py
@@ -1,0 +1,129 @@
+import pytest
+
+from app.models.stock import Stock
+from app.services.safety import check_can_trade, check_stop_loss_take_profit, safety
+
+
+def _setup_stock(db):
+    stock = Stock(code="005930", name="삼성전자", market="KOSPI")
+    db.add(stock)
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def reset_safety():
+    """각 테스트 전 안전장치 리셋."""
+    safety.kill_switch = False
+    safety.daily_max_trades = 50
+    safety.daily_max_amount = 10_000_000
+    safety.stop_loss_pct = -5.0
+    safety.take_profit_pct = 10.0
+    safety._daily_trade_count = 0
+    safety._daily_trade_amount = 0.0
+    yield
+
+
+# --- check_can_trade ---
+
+
+def test_can_trade_normal():
+    ok, reason = check_can_trade(70000, 10)
+    assert ok is True
+
+
+def test_kill_switch_blocks():
+    safety.kill_switch = True
+    ok, reason = check_can_trade(70000, 10)
+    assert ok is False
+    assert "Kill switch" in reason
+
+
+def test_daily_trade_count_limit():
+    safety.daily_max_trades = 2
+    safety._daily_trade_count = 2
+    ok, reason = check_can_trade(70000, 1)
+    assert ok is False
+    assert "횟수" in reason
+
+
+def test_daily_amount_limit():
+    safety.daily_max_amount = 1_000_000
+    safety._daily_trade_amount = 900_000
+    ok, reason = check_can_trade(70000, 10)  # 700,000원 추가 → 초과
+    assert ok is False
+    assert "금액" in reason
+
+
+def test_record_trade():
+    safety.record_trade(500_000)
+    assert safety.daily_trade_count == 1
+    assert safety.daily_trade_amount == 500_000
+
+
+# --- stop loss / take profit ---
+
+
+def test_stop_loss_triggered(db_session):
+    avg_price = 100000
+    current_price = 94000  # -6%
+    result = check_stop_loss_take_profit(db_session, "005930", current_price, avg_price, 10)
+    assert result == "stop_loss"
+
+
+def test_take_profit_triggered(db_session):
+    avg_price = 100000
+    current_price = 111000  # +11%
+    result = check_stop_loss_take_profit(db_session, "005930", current_price, avg_price, 10)
+    assert result == "take_profit"
+
+
+def test_no_trigger(db_session):
+    avg_price = 100000
+    current_price = 102000  # +2%, 임계 미달
+    result = check_stop_loss_take_profit(db_session, "005930", current_price, avg_price, 10)
+    assert result is None
+
+
+# --- API ---
+
+
+def test_api_safety_status(client):
+    response = client.get("/api/safety/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert "kill_switch" in data
+    assert data["kill_switch"] is False
+
+
+def test_api_kill_switch(client):
+    response = client.post("/api/safety/kill-switch", json={"active": True})
+    assert response.json()["kill_switch"] is True
+
+    response = client.post("/api/safety/kill-switch", json={"active": False})
+    assert response.json()["kill_switch"] is False
+
+
+def test_api_update_config(client):
+    response = client.patch(
+        "/api/safety/config",
+        json={"daily_max_trades": 10, "stop_loss_pct": -3.0},
+    )
+    data = response.json()
+    assert data["max_trades"] == 10
+    assert data["stop_loss_pct"] == -3.0
+
+
+def test_kill_switch_blocks_auto_trade(client, db_session):
+    _setup_stock(db_session)
+    client.post(
+        "/api/auto-trade/configs",
+        json={"stock_code": "005930", "strategy_name": "momentum", "quantity": 5},
+    )
+
+    # Kill switch 활성화
+    client.post("/api/safety/kill-switch", json={"active": True})
+
+    # 자동매매 트리거 → 로그 0건 (전부 스킵)
+    client.post("/api/auto-trade/scheduler/trigger")
+    response = client.get("/api/auto-trade/logs")
+    assert len(response.json()) == 0


### PR DESCRIPTION
## Summary
자동매매 안전장치 구현. Kill switch, 일일 매매 한도, 손절/익절 자동 매도.

Closes #24

## Changes
- **Kill Switch**: 활성화 시 모든 자동매매 즉시 중단
- **일일 한도**: 매매 횟수(50회) 및 금액(1000만원) 제한, 초과 시 주문 차단
- **손절/익절**: 보유 종목이 -5% 손실 또는 +10% 이익 시 자동 매도
- **자동매매 통합**: 모든 주문 전 안전장치 체크, 차단 시 `blocked` 로그
- **API**: `GET /api/safety/status`, `POST /api/safety/kill-switch`, `PATCH /api/safety/config`
- 12 new tests (71 total)

## Checklist
- [x] Conventional Commits 메시지 작성
- [x] ruff lint/format 통과
- [x] 테스트 추가 또는 기존 테스트 통과 (71 passed)
- [x] CLAUDE.md 또는 README.md 업데이트 필요 여부 확인