### PR TITLE
feat: 실전 운영 준비 - 로그인, 환경 전환, 자동시작, 잔고동기화

### DIFF
--- a/backend/app/api/auto_trade.py
+++ b/backend/app/api/auto_trade.py
@@ -7,7 +7,7 @@ from app.core.database import get_db
 from app.models.auto_trade import AutoTradeConfig, AutoTradeLog
 from app.services.auto_trader import run_auto_trade_cycle
 from app.services.execution_engine import process_pending_orders
-from app.services.market_data import DummyMarketDataProvider
+from app.services.provider_factory import get_market_provider
 from app.services.scheduler import is_scheduler_running, start_scheduler, stop_scheduler
 
 router = APIRouter(prefix="/api/auto-trade", tags=["auto-trade"], dependencies=[Depends(get_current_user)])
@@ -103,7 +103,7 @@ def scheduler_stop():
 
 @router.post("/scheduler/trigger")
 def scheduler_trigger(db: Session = Depends(get_db)):
-    market = DummyMarketDataProvider()
+    market = get_market_provider()
     logs = run_auto_trade_cycle(db, market)
     process_pending_orders(db, market)
     return {"triggered": True, "configs_checked": len(logs)}

--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.core.auth import get_current_user
-from app.services.market_data import DummyMarketDataProvider
+from app.services.provider_factory import get_market_provider
 from app.strategies.backtest import BacktestMetrics, run_backtest
 from app.strategies.base import Signal
 from app.strategies.runner import STRATEGY_REGISTRY, get_strategy, run_all_strategies
@@ -37,7 +37,7 @@ class AnalyzeResult(BaseModel):
 @router.post("/analyze", response_model=list[AnalyzeResult])
 def analyze(req: AnalyzeRequest):
     # 더미 시세로 가격 데이터 생성
-    market = DummyMarketDataProvider()
+    market = get_market_provider()
     prices = [market.get_price(req.stock_code).current_price for _ in range(30)]
 
     if req.strategy_name:
@@ -97,7 +97,7 @@ def backtest(req: BacktestRequest):
     strategy = get_strategy(req.strategy_name, **(req.params or {}))
 
     # 더미 가격 생성 (과거→현재 순서)
-    market = DummyMarketDataProvider()
+    market = get_market_provider()
     prices = [market.get_price(req.stock_code).current_price for _ in range(req.days)]
 
     result = run_backtest(strategy, req.stock_code, prices, req.initial_capital)

--- a/backend/app/api/trading.py
+++ b/backend/app/api/trading.py
@@ -7,7 +7,7 @@ from app.core.database import get_db
 from app.models.order import OrderSide, OrderStatus, OrderType
 from app.services import order_service
 from app.services.execution_engine import process_pending_orders
-from app.services.market_data import DummyMarketDataProvider
+from app.services.provider_factory import get_market_provider
 
 router = APIRouter(prefix="/api", tags=["trading"], dependencies=[Depends(get_current_user)])
 
@@ -64,7 +64,7 @@ def list_orders(status: OrderStatus | None = None, db: Session = Depends(get_db)
 
 @router.post("/execute")
 def execute_pending_orders(db: Session = Depends(get_db)):
-    market = DummyMarketDataProvider()
+    market = get_market_provider()
     executions = process_pending_orders(db, market)
     return {"executed": len(executions)}
 
@@ -79,7 +79,7 @@ class PriceResponse(BaseModel):
 
 @router.get("/price/{stock_code}", response_model=PriceResponse)
 def get_price(stock_code: str):
-    market = DummyMarketDataProvider()
+    market = get_market_provider()
     return market.get_price(stock_code)
 
 
@@ -96,3 +96,28 @@ def get_portfolio(db: Session = Depends(get_db)):
     from app.models.portfolio import PortfolioItem
 
     return db.query(PortfolioItem).all()
+
+
+@router.post("/portfolio/sync")
+def sync_portfolio(db: Session = Depends(get_db)):
+    """KIS 실제 잔고와 로컬 DB 동기화. virtual/production 환경에서만 동작."""
+    from app.core.config import settings
+    from app.core.kis_config import KisEnvironment
+
+    if settings.kis_env == KisEnvironment.PAPER:
+        return {"error": "Paper mode does not support balance sync"}
+
+    from app.core.kis_config import load_credentials
+    from app.services.balance_sync import sync_balance
+    from app.services.kis_client import KisClient
+
+    try:
+        credentials = load_credentials()
+        client = KisClient(credentials, KisEnvironment(settings.kis_env))
+        result = sync_balance(db, client)
+        client.close()
+        return result
+    except FileNotFoundError:
+        raise HTTPException(status_code=400, detail="KIS credentials not configured")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     secret_key: str = "change-me-in-production-use-32-chars!"
     admin_username: str = "admin"
     admin_password_hash: str = ""  # 초기 셋업 시 설정
+    scheduler_auto_start: bool = False
+    scheduler_interval_minutes: int = 5
 
     model_config = {"env_prefix": "KIS_"}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,11 +10,13 @@ from app.api.safety import router as safety_router
 from app.api.strategy import router as strategy_router
 from app.api.trading import router as trading_router
 from app.core.config import settings
-from app.services.scheduler import stop_scheduler
+from app.services.scheduler import start_scheduler, stop_scheduler
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    if settings.scheduler_auto_start:
+        start_scheduler(settings.scheduler_interval_minutes)
     yield
     stop_scheduler()
 

--- a/backend/app/services/balance_sync.py
+++ b/backend/app/services/balance_sync.py
@@ -1,0 +1,59 @@
+"""KIS 잔고 동기화: 실제 증권사 잔고와 로컬 DB 동기화."""
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models.portfolio import PortfolioItem
+from app.services.kis_client import KisClient
+from app.services.kis_order import KisOrderService
+
+logger = logging.getLogger(__name__)
+
+
+def sync_balance(db: Session, kis_client: KisClient) -> dict:
+    """KIS 실제 잔고를 로컬 DB에 동기화.
+
+    Returns:
+        {"synced": int, "added": int, "removed": int}
+    """
+    order_service = KisOrderService(kis_client)
+    result = order_service.get_balance()
+
+    kis_holdings = {}
+    for item in result.get("output1", []):
+        code = item.get("pdno", "")
+        qty = int(item.get("hldg_qty", "0"))
+        avg_price = float(item.get("pchs_avg_pric", "0"))
+        if qty > 0:
+            kis_holdings[code] = {"quantity": qty, "avg_price": avg_price}
+
+    # 로컬 포트폴리오 조회
+    local_items = db.query(PortfolioItem).all()
+    local_codes = {item.stock_code for item in local_items}
+
+    added = 0
+    removed = 0
+    synced = 0
+
+    # KIS에 있지만 로컬에 없는 종목 추가
+    for code, data in kis_holdings.items():
+        if code not in local_codes:
+            db.add(PortfolioItem(stock_code=code, quantity=data["quantity"], avg_price=data["avg_price"]))
+            added += 1
+        else:
+            # 기존 종목 수량/가격 업데이트
+            item = db.query(PortfolioItem).filter_by(stock_code=code).first()
+            item.quantity = data["quantity"]
+            item.avg_price = data["avg_price"]
+            synced += 1
+
+    # 로컬에 있지만 KIS에 없는 종목 제거
+    for item in local_items:
+        if item.stock_code not in kis_holdings:
+            db.delete(item)
+            removed += 1
+
+    db.commit()
+    logger.info("Balance sync: %d synced, %d added, %d removed", synced, added, removed)
+    return {"synced": synced, "added": added, "removed": removed}

--- a/backend/app/services/provider_factory.py
+++ b/backend/app/services/provider_factory.py
@@ -1,0 +1,56 @@
+"""환경에 따라 적절한 MarketDataProvider를 생성."""
+
+import logging
+
+from app.core.config import settings
+from app.core.kis_config import KisEnvironment, load_credentials
+from app.services.kis_client import KisClient
+from app.services.kis_market import KisMarketDataProvider
+from app.services.market_data import DummyMarketDataProvider, MarketDataProvider
+
+logger = logging.getLogger(__name__)
+
+_provider: MarketDataProvider | None = None
+_kis_client: KisClient | None = None
+
+
+def get_market_provider() -> MarketDataProvider:
+    """현재 환경 설정에 맞는 MarketDataProvider 반환."""
+    global _provider, _kis_client
+
+    if _provider is not None:
+        return _provider
+
+    env = settings.kis_env
+
+    if env == KisEnvironment.PAPER:
+        logger.info("Using DummyMarketDataProvider (paper mode)")
+        _provider = DummyMarketDataProvider()
+
+    elif env in (KisEnvironment.VIRTUAL, KisEnvironment.PRODUCTION):
+        try:
+            credentials = load_credentials()
+            _kis_client = KisClient(credentials, KisEnvironment(env))
+            _provider = KisMarketDataProvider(_kis_client)
+            logger.info("Using KisMarketDataProvider (%s mode)", env)
+        except FileNotFoundError:
+            logger.warning("KIS credentials not found, falling back to DummyMarketDataProvider")
+            _provider = DummyMarketDataProvider()
+        except Exception as e:
+            logger.error("Failed to initialize KIS client: %s, falling back to dummy", e)
+            _provider = DummyMarketDataProvider()
+
+    else:
+        logger.warning("Unknown environment '%s', using DummyMarketDataProvider", env)
+        _provider = DummyMarketDataProvider()
+
+    return _provider
+
+
+def reset_provider():
+    """프로바이더 리셋 (환경 전환 시)."""
+    global _provider, _kis_client
+    if _kis_client:
+        _kis_client.close()
+        _kis_client = None
+    _provider = None

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -6,7 +6,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from app.core.database import SessionLocal
 from app.services.auto_trader import run_auto_trade_cycle
 from app.services.execution_engine import process_pending_orders
-from app.services.market_data import DummyMarketDataProvider
+from app.services.provider_factory import get_market_provider
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def _auto_trade_job():
     logger.info("Auto trade cycle started at %s", datetime.now().strftime("%H:%M:%S"))
     db = SessionLocal()
     try:
-        market = DummyMarketDataProvider()
+        market = get_market_provider()
 
         # 1. 전략 실행 → 시그널 발생 시 주문 생성
         logs = run_auto_trade_cycle(db, market)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Link from "next/link";
+import Nav from "@/components/nav";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -18,14 +18,6 @@ export const metadata: Metadata = {
   description: "한국투자증권 Open API 기반 주식 자동매매 시스템",
 };
 
-const navItems = [
-  { href: "/", label: "대시보드" },
-  { href: "/market", label: "시세 조회" },
-  { href: "/auto-trade", label: "자동매매" },
-  { href: "/portfolio", label: "포트폴리오" },
-  { href: "/orders", label: "주문 내역" },
-];
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -37,24 +29,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-gray-950 text-gray-100">
-        <header className="border-b border-gray-800 bg-gray-900">
-          <div className="mx-auto flex h-14 max-w-7xl items-center gap-6 px-4">
-            <Link href="/" className="text-lg font-bold text-white">
-              KIS Auto Trader
-            </Link>
-            <nav className="flex gap-4">
-              {navItems.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="text-sm text-gray-400 hover:text-white transition-colors"
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </nav>
-          </div>
-        </header>
+        <Nav />
         <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6">
           {children}
         </main>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { setToken } from "@/lib/auth";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isSetup, setIsSetup] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+
+    const endpoint = isSetup ? "/api/auth/setup" : "/api/auth/login";
+
+    try {
+      const res = await fetch(`${API_BASE}${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.detail || "인증 실패");
+        return;
+      }
+
+      setToken(data.access_token);
+      router.push("/");
+    } catch {
+      setError("서버 연결 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-sm rounded-lg border border-gray-800 bg-gray-900 p-8">
+        <h1 className="text-2xl font-bold text-center mb-6">KIS Auto Trader</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">사용자명</label>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              className="w-full rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">비밀번호</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full rounded border border-gray-700 bg-gray-800 px-3 py-2 text-white focus:border-blue-500 focus:outline-none"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded bg-blue-600 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? "처리 중..." : isSetup ? "계정 생성" : "로그인"}
+          </button>
+        </form>
+
+        <button
+          onClick={() => {
+            setIsSetup(!isSetup);
+            setError("");
+          }}
+          className="mt-4 w-full text-center text-sm text-gray-500 hover:text-gray-300"
+        >
+          {isSetup ? "이미 계정이 있습니다" : "처음 사용합니다 (계정 생성)"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/nav.tsx
+++ b/frontend/src/components/nav.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { isAuthenticated, removeToken } from "@/lib/auth";
+
+const navItems = [
+  { href: "/", label: "대시보드" },
+  { href: "/market", label: "시세 조회" },
+  { href: "/auto-trade", label: "자동매매" },
+  { href: "/portfolio", label: "포트폴리오" },
+  { href: "/orders", label: "주문 내역" },
+];
+
+export default function Nav() {
+  const router = useRouter();
+
+  function handleLogout() {
+    removeToken();
+    router.push("/login");
+  }
+
+  return (
+    <header className="border-b border-gray-800 bg-gray-900">
+      <div className="mx-auto flex h-14 max-w-7xl items-center gap-6 px-4">
+        <Link href="/" className="text-lg font-bold text-white">
+          KIS Auto Trader
+        </Link>
+        <nav className="flex flex-1 gap-4">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        {isAuthenticated() && (
+          <button
+            onClick={handleLogout}
+            className="text-sm text-gray-500 hover:text-white transition-colors"
+          >
+            로그아웃
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,13 +1,24 @@
+import { getToken, removeToken } from "./auth";
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = getToken();
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...options?.headers,
     },
   });
+  if (res.status === 401) {
+    removeToken();
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+    throw new Error("Unauthorized");
+  }
   if (!res.ok) {
     throw new Error(`API error: ${res.status}`);
   }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,18 @@
+const TOKEN_KEY = "kis_token";
+
+export function getToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function removeToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function isAuthenticated(): boolean {
+  return !!getToken();
+}


### PR DESCRIPTION
## Summary
API 키 연동 전 필수 구현 사항 전부 완료

Closes #41

## Changes
- **프론트 로그인**: `/login` 페이지, 계정 생성/로그인, JWT 토큰 localStorage 관리, 401 시 자동 리다이렉트
- **로그아웃**: Nav 컴포넌트 분리, 로그아웃 버튼
- **환경 전환**: `provider_factory.py` — KIS_ENV에 따라 Dummy/KIS 자동 전환, KIS 인증 실패 시 Dummy fallback
- **스케줄러 자동시작**: `KIS_SCHEDULER_AUTO_START=true` 환경변수로 서버 부팅 시 자동 실행
- **잔고 동기화**: `POST /api/portfolio/sync` — KIS 실제 잔고를 로컬 DB에 동기화
- 모든 하드코딩된 DummyMarketDataProvider → get_market_provider() 교체

## Checklist
- [x] Conventional Commits
- [x] ruff lint/format 통과
- [x] pytest 79 passed
- [x] ESLint + Next.js build 통과