### PR TITLE
feat: Volume Breakout Retest 전략 (6단계 필터 + ATR TP/SL)

### DIFF
--- a/backend/app/strategies/indicators.py
+++ b/backend/app/strategies/indicators.py
@@ -1,0 +1,123 @@
+"""기술지표 계산 유틸리티."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class MarketRegime(StrEnum):
+    BULL = "bull"
+    BEAR = "bear"
+    SIDE = "side"
+
+
+@dataclass
+class OHLCV:
+    """하루치 캔들 데이터."""
+
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+    turnover: float = 0.0  # 거래대금
+
+
+def atr(candles: list[OHLCV], period: int = 14) -> float:
+    """ATR(Average True Range) 계산.
+
+    Args:
+        candles: 과거→현재 순서
+        period: ATR 기간 (기본 14)
+    """
+    if len(candles) < period + 1:
+        return 0.0
+
+    true_ranges = []
+    for i in range(1, len(candles)):
+        high = candles[i].high
+        low = candles[i].low
+        prev_close = candles[i - 1].close
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        true_ranges.append(tr)
+
+    # 최근 period개의 TR 평균
+    recent = true_ranges[-period:]
+    return sum(recent) / len(recent)
+
+
+def detect_regime(candles: list[OHLCV], ma_period: int = 60) -> MarketRegime:
+    """시장 Regime 판별: 60일 이동평균 대비 현재가 위치.
+
+    Args:
+        candles: 과거→현재 순서
+    """
+    if len(candles) < ma_period:
+        return MarketRegime.SIDE
+
+    closes = [c.close for c in candles]
+    ma = sum(closes[-ma_period:]) / ma_period
+    current = closes[-1]
+
+    pct = (current - ma) / ma * 100
+
+    if pct > 5:
+        return MarketRegime.BULL
+    elif pct < -5:
+        return MarketRegime.BEAR
+    else:
+        return MarketRegime.SIDE
+
+
+def find_peak_day(candles: list[OHLCV], market_cap: float) -> tuple[int, float]:
+    """시총 대비 거래대금이 가장 큰 날(peak day) 찾기.
+
+    Args:
+        candles: 과거→현재 순서
+        market_cap: 시가총액
+
+    Returns:
+        (peak_day_index, turnover_ratio)
+    """
+    if not candles or market_cap <= 0:
+        return -1, 0.0
+
+    peak_idx = -1
+    peak_turnover = 0.0
+
+    for i, c in enumerate(candles):
+        turnover_ratio = c.turnover / market_cap if c.turnover > 0 else 0.0
+        if turnover_ratio > peak_turnover:
+            peak_turnover = turnover_ratio
+            peak_idx = i
+
+    return peak_idx, peak_turnover
+
+
+def is_bullish_candle(candle: OHLCV) -> bool:
+    """양봉 여부."""
+    return candle.close >= candle.open
+
+
+def calc_volume_multiple(candle: OHLCV, avg_volume: float) -> float:
+    """거래량 배수 (현재 거래량 / 평균 거래량)."""
+    if avg_volume <= 0:
+        return 0.0
+    return candle.volume / avg_volume
+
+
+def calc_sizing(current_price: float, min_amount: float = 300_000, max_amount: float = 500_000) -> int:
+    """금액 기반 주문 수량 계산.
+
+    Args:
+        current_price: 현재가
+        min_amount: 최소 주문 금액 (기본 30만원)
+        max_amount: 최대 주문 금액 (기본 50만원)
+
+    Returns:
+        주문 수량 (주)
+    """
+    if current_price <= 0:
+        return 0
+    target_amount = (min_amount + max_amount) / 2
+    qty = int(target_amount / current_price)
+    return max(qty, 1)

--- a/backend/app/strategies/runner.py
+++ b/backend/app/strategies/runner.py
@@ -40,6 +40,8 @@ def run_all_strategies(stock_code: str, prices: list[float]) -> list[StrategyRun
 # 전략 등록
 from app.strategies.golden_cross import GoldenCrossStrategy  # noqa: E402
 from app.strategies.momentum import MomentumStrategy  # noqa: E402
+from app.strategies.volume_breakout import VolumeBreakoutRetestStrategy  # noqa: E402
 
 register_strategy(GoldenCrossStrategy)
 register_strategy(MomentumStrategy)
+register_strategy(VolumeBreakoutRetestStrategy)

--- a/backend/app/strategies/volume_breakout.py
+++ b/backend/app/strategies/volume_breakout.py
@@ -1,0 +1,166 @@
+"""Volume Breakout Retest 전략.
+
+핵심: 과거 N일 중 거래대금이 폭발한 날(peak day)을 찾고,
+충분히 횡보한 뒤 다시 그 가격대에 접근하면 매수.
+"""
+
+from dataclasses import dataclass
+
+from app.strategies.base import BaseStrategy, Signal, StrategyResult
+from app.strategies.indicators import (
+    OHLCV,
+    MarketRegime,
+    atr,
+    calc_sizing,
+    detect_regime,
+    find_peak_day,
+    is_bullish_candle,
+)
+
+# Regime별 TP/SL ATR 배수
+REGIME_PARAMS: dict[MarketRegime, tuple[float, float]] = {
+    MarketRegime.BULL: (5.0, 2.0),
+    MarketRegime.BEAR: (4.0, 2.5),
+    MarketRegime.SIDE: (3.0, 1.8),
+}
+
+
+@dataclass
+class VolumeBreakoutResult:
+    """전략 분석 결과 상세."""
+
+    signal: Signal
+    reason: str
+    confidence: float = 0.0
+    tp_price: float = 0.0  # Take Profit 가격
+    sl_price: float = 0.0  # Stop Loss 가격
+    suggested_qty: int = 0  # 추천 주문 수량
+    regime: MarketRegime = MarketRegime.SIDE
+
+
+class VolumeBreakoutRetestStrategy(BaseStrategy):
+    """Volume Breakout Retest 전략."""
+
+    name = "volume_breakout_retest"
+    description = "거래대금 폭발일 앵커 → 횡보 → 재접근 시 매수 (6단계 필터)"
+
+    def __init__(
+        self,
+        lookback: int = 132,
+        min_turnover_pct: float = 10.0,
+        fomo_gain_pct: float = 5.0,
+        fomo_vol_multiple: float = 3.0,
+        min_days_since_peak: int = 15,
+        max_breakthrough_pct: float = 15.0,
+        proximity_pct: float = 3.0,
+        min_amount_krw: float = 300_000,
+        max_amount_krw: float = 500_000,
+    ):
+        self.lookback = lookback
+        self.min_turnover_pct = min_turnover_pct
+        self.fomo_gain_pct = fomo_gain_pct
+        self.fomo_vol_multiple = fomo_vol_multiple
+        self.min_days_since_peak = min_days_since_peak
+        self.max_breakthrough_pct = max_breakthrough_pct
+        self.proximity_pct = proximity_pct
+        self.min_amount_krw = min_amount_krw
+        self.max_amount_krw = max_amount_krw
+
+    def analyze(self, prices: list[float]) -> StrategyResult:
+        """BaseStrategy 인터페이스 호환. 단순 가격 리스트만으로는 제한적."""
+        if len(prices) < self.min_days_since_peak + 5:
+            return StrategyResult(signal=Signal.HOLD, reason="데이터 부족")
+        return StrategyResult(signal=Signal.HOLD, reason="OHLCV 데이터 필요 (analyze_candles 사용)")
+
+    def analyze_candles(self, candles: list[OHLCV], market_cap: float) -> VolumeBreakoutResult:
+        """OHLCV 캔들 데이터 기반 전략 분석.
+
+        Args:
+            candles: 과거→현재 순서
+            market_cap: 시가총액
+        """
+        if len(candles) < self.min_days_since_peak + 5:
+            return VolumeBreakoutResult(signal=Signal.HOLD, reason="데이터 부족")
+
+        # lookback 범위 제한
+        window = candles[-self.lookback :] if len(candles) > self.lookback else candles
+
+        # Step 1: Peak day 찾기 + turnover 체크
+        peak_idx, turnover_ratio = find_peak_day(window, market_cap)
+        if peak_idx < 0:
+            return VolumeBreakoutResult(signal=Signal.HOLD, reason="peak day 없음")
+
+        turnover_pct = turnover_ratio * 100
+        if turnover_pct < self.min_turnover_pct:
+            return VolumeBreakoutResult(
+                signal=Signal.HOLD,
+                reason=f"turnover {turnover_pct:.1f}% < {self.min_turnover_pct}%",
+            )
+
+        peak_candle = window[peak_idx]
+
+        # Step 2: 양봉 체크
+        if not is_bullish_candle(peak_candle):
+            return VolumeBreakoutResult(signal=Signal.HOLD, reason="peak day 음봉, 투매")
+
+        # Step 3: FOMO 제외 (오늘 기준)
+        today = window[-1]
+        today_gain = (today.close - today.open) / today.open * 100 if today.open > 0 else 0
+        avg_vol = sum(c.volume for c in window) / len(window) if window else 1
+        vol_multiple = today.volume / avg_vol if avg_vol > 0 else 0
+
+        if today_gain >= self.fomo_gain_pct and vol_multiple < self.fomo_vol_multiple:
+            return VolumeBreakoutResult(
+                signal=Signal.HOLD,
+                reason=f"FOMO: +{today_gain:.1f}% vol x{vol_multiple:.1f}",
+            )
+
+        # Step 4: 횡보 충분 체크
+        days_since_peak = len(window) - 1 - peak_idx
+        if days_since_peak < self.min_days_since_peak:
+            return VolumeBreakoutResult(
+                signal=Signal.HOLD,
+                reason=f"days_since={days_since_peak} < {self.min_days_since_peak}",
+            )
+
+        # Step 5: 추격 금지 (peak 이후 최고가 체크)
+        post_peak = window[peak_idx + 1 :]
+        if post_peak:
+            max_after_peak = max(c.high for c in post_peak)
+            breakthrough_pct = (max_after_peak - peak_candle.close) / peak_candle.close * 100
+            if breakthrough_pct >= self.max_breakthrough_pct:
+                return VolumeBreakoutResult(
+                    signal=Signal.HOLD,
+                    reason=f"breakthrough {breakthrough_pct:.1f}% >= {self.max_breakthrough_pct}%",
+                )
+
+        # Step 6: 근접도 체크
+        current_price = today.close
+        proximity = (current_price - peak_candle.close) / peak_candle.close * 100
+        if abs(proximity) > self.proximity_pct:
+            return VolumeBreakoutResult(
+                signal=Signal.HOLD,
+                reason=f"proximity {proximity:+.1f}% too far (±{self.proximity_pct}%)",
+            )
+
+        # 모든 조건 통과 → BUY
+        regime = detect_regime(candles)
+        k_tp, k_sl = REGIME_PARAMS[regime]
+        current_atr = atr(candles)
+
+        tp_price = current_price + k_tp * current_atr
+        sl_price = current_price - k_sl * current_atr
+        suggested_qty = calc_sizing(current_price, self.min_amount_krw, self.max_amount_krw)
+
+        return VolumeBreakoutResult(
+            signal=Signal.BUY,
+            reason=(
+                f"재접근 매수 (peak turnover {turnover_pct:.1f}%, "
+                f"{days_since_peak}일 횡보, proximity {proximity:+.1f}%)"
+            ),
+            confidence=min(turnover_pct / 20, 1.0),
+            tp_price=round(tp_price),
+            sl_price=round(sl_price),
+            suggested_qty=suggested_qty,
+            regime=regime,
+        )

--- a/backend/tests/test_strategies.py
+++ b/backend/tests/test_strategies.py
@@ -150,7 +150,7 @@ def test_api_analyze(client):
     response = client.post("/api/strategy/analyze", json={"stock_code": "005930"})
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2  # golden_cross + momentum
+    assert len(data) == 3  # golden_cross + momentum + volume_breakout_retest
 
 
 def test_api_backtest(client):

--- a/backend/tests/test_volume_breakout.py
+++ b/backend/tests/test_volume_breakout.py
@@ -1,0 +1,193 @@
+from app.strategies.base import Signal
+from app.strategies.indicators import OHLCV, MarketRegime, atr, calc_sizing, detect_regime, find_peak_day
+from app.strategies.volume_breakout import VolumeBreakoutRetestStrategy
+
+
+def _make_candle(
+    close: float,
+    volume: int = 1000,
+    turnover: float = 0,
+    open_: float | None = None,
+    high: float | None = None,
+    low: float | None = None,
+) -> OHLCV:
+    o = open_ if open_ is not None else close * 0.99
+    h = high if high is not None else close * 1.01
+    lo = low if low is not None else close * 0.98
+    return OHLCV(open=o, high=h, low=lo, close=close, volume=volume, turnover=turnover)
+
+
+def _make_scenario(
+    peak_price: float = 10000,
+    peak_turnover: float = 15_000_000_000,  # 150억 거래대금
+    market_cap: float = 100_000_000_000,  # 1000억 시총
+    days_after_peak: int = 20,
+    current_price: float | None = None,
+):
+    """peak day + 횡보 + 현재가 근접 시나리오 생성."""
+    candles = []
+
+    # peak 전 데이터 (20일)
+    for i in range(20):
+        candles.append(_make_candle(peak_price * 0.95, volume=500, turnover=5_000_000_000))
+
+    # peak day (양봉, 거래대금 폭발)
+    candles.append(
+        OHLCV(
+            open=peak_price * 0.98,
+            high=peak_price * 1.05,
+            low=peak_price * 0.97,
+            close=peak_price,
+            volume=50000,
+            turnover=peak_turnover,
+        )
+    )
+
+    # 횡보 구간
+    for i in range(days_after_peak):
+        price = peak_price * (1 + (i % 3 - 1) * 0.005)  # ±0.5% 횡보
+        candles.append(_make_candle(price, volume=1000, turnover=2_000_000_000))
+
+    # 현재가 (peak 근처로 복귀)
+    final_price = current_price if current_price else peak_price * 1.01
+    candles.append(_make_candle(final_price, volume=1200, turnover=3_000_000_000))
+
+    return candles, market_cap
+
+
+# --- Indicator tests ---
+
+
+def test_atr():
+    candles = [_make_candle(100 + i, volume=1000) for i in range(20)]
+    result = atr(candles, period=14)
+    assert result > 0
+
+
+def test_detect_regime_bull():
+    candles = [_make_candle(100 + i * 2, volume=1000) for i in range(80)]
+    regime = detect_regime(candles)
+    assert regime == MarketRegime.BULL
+
+
+def test_detect_regime_bear():
+    candles = [_make_candle(200 - i * 2, volume=1000) for i in range(80)]
+    regime = detect_regime(candles)
+    assert regime == MarketRegime.BEAR
+
+
+def test_find_peak_day():
+    candles = [_make_candle(100, volume=1000, turnover=1_000_000) for _ in range(10)]
+    candles[5] = _make_candle(100, volume=50000, turnover=50_000_000)  # peak
+    idx, ratio = find_peak_day(candles, market_cap=100_000_000)
+    assert idx == 5
+    assert ratio > 0
+
+
+def test_calc_sizing():
+    # 10,000원 → 40만원/10,000원 = 40주
+    assert calc_sizing(10000) == 40
+    # 500,000원 → 40만원/500,000원 = 0 → min 1주
+    assert calc_sizing(500000) == 1
+
+
+# --- Strategy tests ---
+
+
+def test_buy_signal():
+    """모든 조건 충족 → BUY."""
+    candles, market_cap = _make_scenario(
+        peak_price=10000,
+        days_after_peak=20,
+        current_price=10050,
+    )
+    strategy = VolumeBreakoutRetestStrategy(
+        min_turnover_pct=10.0,
+        min_days_since_peak=15,
+        proximity_pct=3.0,
+    )
+    result = strategy.analyze_candles(candles, market_cap)
+    assert result.signal == Signal.BUY
+    assert result.tp_price > 0
+    assert result.sl_price > 0
+    assert result.suggested_qty > 0
+
+
+def test_low_turnover():
+    """거래대금 부족 → HOLD."""
+    candles, market_cap = _make_scenario(
+        peak_turnover=5_000_000_000,  # 5% < 10%
+    )
+    strategy = VolumeBreakoutRetestStrategy(min_turnover_pct=10.0)
+    result = strategy.analyze_candles(candles, market_cap)
+    assert result.signal == Signal.HOLD
+    assert "turnover" in result.reason
+
+
+def test_bearish_peak():
+    """음봉 peak day → HOLD."""
+    candles, market_cap = _make_scenario()
+    # peak day를 음봉으로 변경
+    peak_idx = 20
+    candles[peak_idx] = OHLCV(
+        open=10500,
+        high=10600,
+        low=9800,
+        close=9900,
+        volume=50000,
+        turnover=15_000_000_000,
+    )
+    strategy = VolumeBreakoutRetestStrategy()
+    result = strategy.analyze_candles(candles, market_cap)
+    assert result.signal == Signal.HOLD
+    assert "음봉" in result.reason
+
+
+def test_insufficient_days():
+    """횡보 기간 부족 → HOLD."""
+    candles, market_cap = _make_scenario(days_after_peak=5)
+    strategy = VolumeBreakoutRetestStrategy(min_days_since_peak=15)
+    result = strategy.analyze_candles(candles, market_cap)
+    assert result.signal == Signal.HOLD
+    assert "days_since" in result.reason
+
+
+def test_too_far_proximity():
+    """현재가가 peak에서 너무 멀음 → HOLD."""
+    candles, market_cap = _make_scenario(current_price=11000)  # +10%
+    strategy = VolumeBreakoutRetestStrategy(proximity_pct=3.0)
+    result = strategy.analyze_candles(candles, market_cap)
+    assert result.signal == Signal.HOLD
+    assert "proximity" in result.reason
+
+
+def test_regime_affects_tp_sl():
+    """Regime에 따라 TP/SL 배수 달라짐."""
+    candles, market_cap = _make_scenario(days_after_peak=20, current_price=10050)
+    strategy = VolumeBreakoutRetestStrategy()
+    result = strategy.analyze_candles(candles, market_cap)
+
+    if result.signal == Signal.BUY:
+        # TP > 현재가, SL < 현재가
+        assert result.tp_price > candles[-1].close
+        assert result.sl_price < candles[-1].close
+
+
+def test_strategy_registered():
+    from app.strategies.runner import STRATEGY_REGISTRY
+
+    assert "volume_breakout_retest" in STRATEGY_REGISTRY
+
+
+def test_api_strategy_list_includes_volume_breakout(client):
+    response = client.get("/api/strategy/list")
+    names = [s["name"] for s in response.json()]
+    assert "volume_breakout_retest" in names
+
+
+def test_insufficient_data():
+    """데이터 부족 → HOLD."""
+    candles = [_make_candle(100) for _ in range(5)]
+    strategy = VolumeBreakoutRetestStrategy()
+    result = strategy.analyze_candles(candles, 100_000_000_000)
+    assert result.signal == Signal.HOLD


### PR DESCRIPTION
## Summary
거래대금 폭발일 앵커 → 횡보 → 재접근 시 매수하는 퀀트 전략 구현

Closes #44

## 전략 로직
1. **Peak Day 탐색**: 132거래일 내 시총 대비 거래대금 최대일
2. **6단계 순차 필터**: turnover → 양봉 → FOMO → 횡보 → 추격 → 근접도
3. **ATR(14) 기반 TP/SL**: Regime별 다른 배수 (BULL/BEAR/SIDE)
4. **자동 사이징**: 30~50만원/종목 기준

## Changes
- `indicators.py`: ATR, regime detection, peak day finder, sizing
- `volume_breakout.py`: VolumeBreakoutRetestStrategy + VolumeBreakoutResult
- 전략 레지스트리 등록
- 14 new tests (96 total)

## Checklist
- [x] Conventional Commits
- [x] ruff + pytest 96 passed