### PR TITLE
feat: 24시간 운영 안정화 - 장 시간, 로깅, DB 백업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ Thumbs.db
 # DB
 *.db
 
+# 로그
+logs/
+
+# 백업
+backups/
+
 # 테스트 / 커버리지
 .coverage
 htmlcov/

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,0 +1,40 @@
+"""로깅 설정: 파일 + 콘솔 출력, 로테이션."""
+
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+LOG_DIR = Path("logs")
+LOG_FILE = LOG_DIR / "kis_auto_trader.log"
+MAX_BYTES = 10 * 1024 * 1024  # 10MB
+BACKUP_COUNT = 5
+
+
+def setup_logging(level: str = "INFO"):
+    """로깅 초기화. 콘솔 + 파일 동시 출력."""
+    LOG_DIR.mkdir(exist_ok=True)
+
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # 파일 핸들러 (로테이션)
+    file_handler = RotatingFileHandler(LOG_FILE, maxBytes=MAX_BYTES, backupCount=BACKUP_COUNT, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    # 콘솔 핸들러
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+
+    # 루트 로거 설정
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+    root.addHandler(file_handler)
+    root.addHandler(console_handler)
+
+    # 외부 라이브러리 로그 레벨 조정
+    logging.getLogger("uvicorn").setLevel(logging.WARNING)
+    logging.getLogger("apscheduler").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,11 +11,13 @@ from app.api.scan_config import router as scan_config_router
 from app.api.strategy import router as strategy_router
 from app.api.trading import router as trading_router
 from app.core.config import settings
+from app.core.logging_config import setup_logging
 from app.services.scheduler import start_scheduler, stop_scheduler
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    setup_logging("DEBUG" if settings.debug else "INFO")
     if settings.scheduler_auto_start:
         start_scheduler(settings.scheduler_interval_minutes)
     yield

--- a/backend/app/services/market_hours.py
+++ b/backend/app/services/market_hours.py
@@ -1,0 +1,100 @@
+"""한국 주식시장 운영 시간 관리."""
+
+from datetime import date, datetime, time
+
+# 정규장 시간
+MARKET_OPEN = time(9, 0)
+MARKET_CLOSE = time(15, 30)
+
+# 2025~2026 한국 공휴일 (매년 업데이트 필요)
+HOLIDAYS: set[date] = {
+    # 2025
+    date(2025, 1, 1),  # 신정
+    date(2025, 1, 28),  # 설날 연휴
+    date(2025, 1, 29),  # 설날
+    date(2025, 1, 30),  # 설날 연휴
+    date(2025, 3, 1),  # 삼일절
+    date(2025, 5, 5),  # 어린이날
+    date(2025, 5, 6),  # 대체공휴일
+    date(2025, 6, 6),  # 현충일
+    date(2025, 8, 15),  # 광복절
+    date(2025, 10, 3),  # 개천절
+    date(2025, 10, 5),  # 추석 연휴
+    date(2025, 10, 6),  # 추석
+    date(2025, 10, 7),  # 추석 연휴
+    date(2025, 10, 8),  # 대체공휴일
+    date(2025, 10, 9),  # 한글날
+    date(2025, 12, 25),  # 크리스마스
+    # 2026
+    date(2026, 1, 1),  # 신정
+    date(2026, 2, 16),  # 설날 연휴
+    date(2026, 2, 17),  # 설날
+    date(2026, 2, 18),  # 설날 연휴
+    date(2026, 3, 1),  # 삼일절
+    date(2026, 3, 2),  # 대체공휴일
+    date(2026, 5, 5),  # 어린이날
+    date(2026, 5, 24),  # 석가탄신일
+    date(2026, 6, 6),  # 현충일
+    date(2026, 8, 15),  # 광복절
+    date(2026, 9, 24),  # 추석 연휴
+    date(2026, 9, 25),  # 추석
+    date(2026, 9, 26),  # 추석 연휴
+    date(2026, 10, 3),  # 개천절
+    date(2026, 10, 9),  # 한글날
+    date(2026, 12, 25),  # 크리스마스
+}
+
+
+def is_market_open(now: datetime | None = None) -> bool:
+    """현재 시각이 정규장 시간인지 확인."""
+    if now is None:
+        now = datetime.now()
+
+    # 주말 체크
+    if now.weekday() >= 5:  # 토(5), 일(6)
+        return False
+
+    # 공휴일 체크
+    if now.date() in HOLIDAYS:
+        return False
+
+    # 시간 체크
+    current_time = now.time()
+    return MARKET_OPEN <= current_time <= MARKET_CLOSE
+
+
+def is_trading_day(today: date | None = None) -> bool:
+    """오늘이 거래일인지 확인 (시간 무관)."""
+    if today is None:
+        today = date.today()
+
+    if today.weekday() >= 5:
+        return False
+
+    if today in HOLIDAYS:
+        return False
+
+    return True
+
+
+def next_market_open(now: datetime | None = None) -> datetime:
+    """다음 장 시작 시각 반환."""
+    if now is None:
+        now = datetime.now()
+
+    candidate = now.replace(hour=9, minute=0, second=0, microsecond=0)
+
+    # 오늘 장 시작 전이고 거래일이면
+    if now.time() < MARKET_OPEN and is_trading_day(now.date()):
+        return candidate
+
+    # 다음 거래일 찾기
+    from datetime import timedelta
+
+    check = now.date() + timedelta(days=1)
+    for _ in range(10):  # 최대 10일 탐색
+        if is_trading_day(check):
+            return datetime.combine(check, MARKET_OPEN)
+        check += timedelta(days=1)
+
+    return candidate

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -6,6 +6,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from app.core.database import SessionLocal
 from app.services.auto_trader import run_auto_trade_cycle
 from app.services.execution_engine import process_pending_orders
+from app.services.market_hours import is_market_open
 from app.services.provider_factory import get_market_provider
 
 logger = logging.getLogger(__name__)
@@ -15,6 +16,10 @@ _scheduler: BackgroundScheduler | None = None
 
 def _auto_trade_job():
     """스케줄러가 호출하는 자동매매 작업."""
+    if not is_market_open():
+        logger.debug("Market closed, skipping auto trade cycle")
+        return
+
     logger.info("Auto trade cycle started at %s", datetime.now().strftime("%H:%M:%S"))
     db = SessionLocal()
     try:
@@ -51,7 +56,7 @@ def start_scheduler(interval_minutes: int = 5):
     _scheduler = BackgroundScheduler()
     _scheduler.add_job(_auto_trade_job, "interval", minutes=interval_minutes, id="auto_trade")
     _scheduler.start()
-    logger.info("Scheduler started (interval: %d min)", interval_minutes)
+    logger.info("Scheduler started (interval: %d min, market hours only)", interval_minutes)
 
 
 def stop_scheduler():
@@ -69,5 +74,14 @@ def is_scheduler_running() -> bool:
 
 
 def trigger_now():
-    """즉시 한 번 실행 (테스트/수동 트리거용)."""
-    _auto_trade_job()
+    """즉시 한 번 실행 (테스트/수동 트리거용). 장 시간 체크 무시."""
+    logger.info("Manual trigger at %s", datetime.now().strftime("%H:%M:%S"))
+    db = SessionLocal()
+    try:
+        market = get_market_provider()
+        run_auto_trade_cycle(db, market)
+        process_pending_orders(db, market)
+    except Exception as e:
+        logger.error("Manual trigger failed: %s", e)
+    finally:
+        db.close()

--- a/backend/tests/test_market_hours.py
+++ b/backend/tests/test_market_hours.py
@@ -1,0 +1,60 @@
+from datetime import date, datetime
+
+from app.services.market_hours import is_market_open, is_trading_day, next_market_open
+
+
+def test_market_open_during_hours():
+    # 수요일 10시 → 장중
+    dt = datetime(2026, 4, 29, 10, 0)  # 수요일
+    assert is_market_open(dt) is True
+
+
+def test_market_closed_before_open():
+    dt = datetime(2026, 4, 29, 8, 30)
+    assert is_market_open(dt) is False
+
+
+def test_market_closed_after_close():
+    dt = datetime(2026, 4, 29, 16, 0)
+    assert is_market_open(dt) is False
+
+
+def test_market_closed_weekend():
+    dt = datetime(2026, 5, 2, 10, 0)  # 토요일
+    assert is_market_open(dt) is False
+
+
+def test_market_closed_holiday():
+    dt = datetime(2026, 3, 1, 10, 0)  # 삼일절
+    assert is_market_open(dt) is False
+
+
+def test_is_trading_day_weekday():
+    assert is_trading_day(date(2026, 4, 29)) is True  # 수요일
+
+
+def test_is_trading_day_weekend():
+    assert is_trading_day(date(2026, 5, 2)) is False  # 토요일
+
+
+def test_is_trading_day_holiday():
+    assert is_trading_day(date(2026, 1, 1)) is False  # 신정
+
+
+def test_next_market_open_same_day():
+    dt = datetime(2026, 4, 29, 7, 0)  # 수요일 오전 7시
+    result = next_market_open(dt)
+    assert result.hour == 9
+    assert result.date() == date(2026, 4, 29)
+
+
+def test_next_market_open_after_close():
+    dt = datetime(2026, 4, 29, 16, 0)  # 수요일 장 마감 후
+    result = next_market_open(dt)
+    assert result.date() == date(2026, 4, 30)  # 다음 날
+
+
+def test_next_market_open_friday_evening():
+    dt = datetime(2026, 5, 1, 16, 0)  # 금요일 장 마감 후
+    result = next_market_open(dt)
+    assert result.weekday() == 0  # 월요일

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,23 @@ services:
       interval: 5s
       retries: 5
 
+  db-backup:
+    image: postgres:16-alpine
+    environment:
+      PGPASSWORD: ${DB_PASSWORD:-kis_dev_password}
+    volumes:
+      - ./backups:/backups
+    entrypoint: >
+      sh -c "while true; do
+        pg_dump -h db -U kis kis_auto_trader > /backups/backup_$$(date +%Y%m%d_%H%M%S).sql
+        find /backups -name '*.sql' -mtime +7 -delete
+        sleep 86400
+      done"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
   backend:
     build: ./backend
     ports:
@@ -23,6 +40,10 @@ services:
       - KIS_SECRET_KEY=${SECRET_KEY:-change-me-in-production-use-32-chars!}
       - KIS_KIS_ENV=paper
       - KIS_DATABASE_URL=postgresql://kis:${DB_PASSWORD:-kis_dev_password}@db:5432/kis_auto_trader
+      - KIS_SCHEDULER_AUTO_START=${SCHEDULER_AUTO_START:-false}
+      - KIS_SCHEDULER_INTERVAL_MINUTES=${SCHEDULER_INTERVAL:-5}
+    volumes:
+      - backend-logs:/app/logs
     depends_on:
       db:
         condition: service_healthy
@@ -40,3 +61,4 @@ services:
 
 volumes:
   pgdata:
+  backend-logs:


### PR DESCRIPTION
## Summary
홈서버 24시간 운영을 위한 안정화 3종

Closes #49

## Changes
- **장 시간 체크**: 정규장 09:00~15:30, 토/일, 2025~2026 공휴일
  - 스케줄러가 장외 시간에는 자동 스킵
- **로그 관리**: 파일 저장 + 로테이션 (10MB x 5파일)
- **DB 백업**: Docker Compose에 pg_dump 매일 자동 + 7일 보관
- 11 new tests (126 total)

## Checklist
- [x] Conventional Commits
- [x] ruff + pytest 126 passed